### PR TITLE
feat(performance): force mounted render to back of queue

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -26,12 +26,6 @@
                 </template>
             </br-page>
         </div>
-        <noscript>
-            <component :is="'style'">
-            .skeleton-site { display: none !important }
-            .hydrate { display: block !important }
-            </component>
-        </noscript>
     </div>
 </template>
 
@@ -74,7 +68,9 @@ const { data: xForwardedhost } = await useFetch('/api/getXForwardedHost');
 const isMounted = ref(false);
 
 onMounted(() => {
-    isMounted.value = true;
+    setTimeout(() => {
+        isMounted.value = true;
+    }, 50);
 });
 
 // let deLocalisedRoute = route;


### PR DESCRIPTION
Currently there is a white screen in between the skeleton disappearing the site actually rendering on the nuxt sites which is quite ugly and breaks the perception that the skeleton makes it feel faster. Adding a very brief delay to that mounted flag shoves it to the back of the queue of things that happen onMounted and seems to ensure that it always fires in the proper sequence, rendering the site then hiding the skeleton