### PR TITLE
feat(component library): update to 4.0.0, correct spacer tokens

### DIFF
--- a/components/Modules/VsBrForm.vue
+++ b/components/Modules/VsBrForm.vue
@@ -1,6 +1,6 @@
 <template>
     <VsContainer
-        class="mb-10"
+        class="mb-400"
     >
         <VsRow>
             <VsCol

--- a/components/Modules/VsBrLongCopyModule.vue
+++ b/components/Modules/VsBrLongCopyModule.vue
@@ -1,6 +1,6 @@
 <template>
     <VsContainer
-        class="mb-10"
+        class="mb-400"
     >
         <VsRow>
             <VsCol

--- a/components/Modules/VsBrNewsletterSignpost.vue
+++ b/components/Modules/VsBrNewsletterSignpost.vue
@@ -16,7 +16,7 @@
                 >
                     <VsRichTextWrapper
                         variant="lead"
-                        class="mb-9 mb-lg-10"
+                        class="mb-300 mb-lg-400"
                     >
                         <VsBrRichText :input-content="data.copy.value" />
                     </VsRichTextWrapper>
@@ -39,7 +39,7 @@
                 >
                     <VsImg
                         src="/illustrations/newsletter.svg"
-                        class="mt-10 mt-sm-2 w-100 h-auto"
+                        class="mt-400 mt-sm-050 w-100 h-auto"
                         style="aspect-ratio:267/206"
                     />
                 </VsCol>

--- a/components/Modules/VsBrPreviewError.vue
+++ b/components/Modules/VsBrPreviewError.vue
@@ -1,10 +1,10 @@
 <template>
     <VsContainer
-        class="py-4"
+        class="py-100"
     >
         <VsAlert>
             <div>
-                <p class="text-danger pb-2">
+                <p class="text-danger pb-050">
                     <strong>CMS ERROR!</strong>
                 </p>
 

--- a/components/PageTypes/VsBrGeneral.vue
+++ b/components/PageTypes/VsBrGeneral.vue
@@ -41,7 +41,7 @@
         <!-- TODO - labels -->
         <VsBrProductSearch
             v-if="productSearch && productSearch.position === 'Top'"
-            class="mb-9 mb-lg-12 pt-9"
+            class="mb-300 mb-lg-600 pt-300"
         />
     </NuxtLazyHydrate>
 
@@ -56,7 +56,7 @@
         <!-- TODO - labels -->
         <VsBrProductSearch
             v-if="productSearch && productSearch.position === 'Bottom'"
-            class="mt-9 mt-lg-12"
+            class="mt-300 mt-lg-600"
         />
     </NuxtLazyHydrate>
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@bloomreach/spa-sdk": "^23.3.2",
     "@bloomreach/vue3-sdk": "^22.0.5",
     "@pinia/nuxt": "^0.5.3",
-    "@visitscotland/component-library": "^3.3.7",
+    "@visitscotland/component-library": "^4.0.0",
     "axios": "^1.7.7",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,10 +2445,10 @@
     node-gyp-build "^4.2.2"
     resolve-from "^5.0.0"
 
-"@visitscotland/component-library@^3.3.7":
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/@visitscotland/component-library/-/component-library-3.3.7.tgz#ade079441bd5c5056c03bf1d507e3f8e978a8aed"
-  integrity sha512-X0R6cECK1f3OUFvFw1KMIXHZQPfXkL5iG6Z/yxGBGbqLjxaAn+glVrz83RkcmLDfRcVo8Efcm4N+vlZEdFo+OA==
+"@visitscotland/component-library@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@visitscotland/component-library/-/component-library-4.0.0.tgz#bed864d7cf722a4e6fa176a9370168e3915acfda"
+  integrity sha512-dCmR4xOZYxBOCKn/0oxJCtttqfHiA7xNVlfK+HeHfl37IzPv/UK3vFGn14ceXz7qBmaZY3wQM05acl75/oa6wQ==
   dependencies:
     "@mapbox/geojson-extent" "^1.0.1"
     "@pinia/testing" "^0.1.3"
@@ -9615,16 +9615,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9716,14 +9707,7 @@ stringify-package@^1.0.1:
   resolved "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10770,16 +10754,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
I think this is all that's needed for the 4.0 update here, there are no VsHeadings in the site, the only VsButton takes no props anyway and is meant to be rounded and the only VsCaption is an un-themed one in ImageWithCaption