### PR TITLE
Megalink theme bugfix

### DIFF
--- a/components/Modules/VsBrModuleBuilder.vue
+++ b/components/Modules/VsBrModuleBuilder.vue
@@ -144,7 +144,7 @@ if (modules) {
         }
 
         modules[x].themeIndex = newThemeIndex;
-        modules[x].themeValue = themeCalculator(newThemeIndex, modules[x]);
+        modules[x].themeValue = themeCalculator(newThemeIndex);
 
         if (modules[x].hippoBean) {
             hippoContent[x] = page.getContent(modules[x].hippoBean);

--- a/components/PageTypes/VsBrGeneral.vue
+++ b/components/PageTypes/VsBrGeneral.vue
@@ -122,13 +122,21 @@ if (page.value) {
         otyml = configStore.otyml;
     }
 
-    if (pageItems && pageItems.length
-        && (
-            pageItems[0].type === 'ListLinksModule'
-            || pageItems[0].type === 'MultiImageLinksModule'
-        )
-    ) {
-        firstModuleIsLink = true;
+    console.log(pageItems[0].type);
+
+    if (pageItems && pageItems.length) {
+        let firstNonPersonalisationModule = 0;
+
+        if (pageItems.length > 1 && pageItems[0].type === 'PersonalisationModule') {
+            firstNonPersonalisationModule = 1;
+        }
+
+        if (
+            pageItems[firstNonPersonalisationModule].type === 'ListLinksModule'
+            || pageItems[firstNonPersonalisationModule].type === 'MultiImageLinksModule'
+        ) {
+            firstModuleIsLink = true;
+        }
     }
 }
 </script>

--- a/components/PageTypes/VsBrGeneral.vue
+++ b/components/PageTypes/VsBrGeneral.vue
@@ -122,8 +122,6 @@ if (page.value) {
         otyml = configStore.otyml;
     }
 
-    console.log(pageItems[0].type);
-
     if (pageItems && pageItems.length) {
         let firstNonPersonalisationModule = 0;
 

--- a/components/PageTypes/VsBrGeneral.vue
+++ b/components/PageTypes/VsBrGeneral.vue
@@ -134,6 +134,7 @@ if (page.value) {
         if (
             pageItems[firstNonPersonalisationModule].type === 'ListLinksModule'
             || pageItems[firstNonPersonalisationModule].type === 'MultiImageLinksModule'
+            || pageItems[firstNonPersonalisationModule].type === 'SingleImageLinksModule'
         ) {
             firstModuleIsLink = true;
         }


### PR DESCRIPTION
The themes set up on the nuxt sites is slightly broken at the moment, a change made in the front end ages ago to remove references to modules that don't exist outside of .com broke the alternating part, and the addition of the (invisible) personalisation module means the check to see what theme the intro should have isn't correct.

Once this is sorted here I'll copy the fix over to BSH/the starter

https://visitscotland.atlassian.net/browse/DS-836